### PR TITLE
Loader will ignore inline comments

### DIFF
--- a/envdiff/loader.py
+++ b/envdiff/loader.py
@@ -12,7 +12,13 @@ class Loader():
         # Removes empty lines
         contents = list(filter(lambda item: item, contents))
 
-        return list(filter(self.comment_filter, contents))
+        # Remove commented out lines
+        contents = list(filter(self.comment_filter, contents))
+
+        # Trim lines with comments at the end
+        contents = [ line.split(' #')[0] for line in contents ]
+
+        return contents
 
     def comment_filter(self, line):
         """

--- a/envdiff/logger.py
+++ b/envdiff/logger.py
@@ -91,7 +91,7 @@ class Logger():
         right_table = Table(title=f'Unique {right_filename} Environment Variables', box=box.ROUNDED, header_style=self.header_style, expand=True)
         right_table.add_column('Variable', justify='right')
         right_table.add_column('Value', style='red')
-        
+
         for k, v in unique_right:
             right_table.add_row(k, v, style=self.right_style)
 

--- a/test/fixtures/.env-with-inline-comment
+++ b/test/fixtures/.env-with-inline-comment
@@ -1,1 +1,2 @@
+# full line comment
 FOO=BAR # inline comment

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -22,7 +22,6 @@ class TestLoader(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertFalse(result.count(''))
 
-    @unittest.expectedFailure
     def test_does_not_include_comments_that_follow_values(self):
         expected = ['FOO=BAR']
 


### PR DESCRIPTION
The file loader will now remove comments mid-way through a line, not just lines that are entirely comments.