### PR TITLE
Allow the passing custom comment & separator characters from the command line

### DIFF
--- a/.env-tc-prod
+++ b/.env-tc-prod
@@ -1,0 +1,14 @@
+// EXAMPLE ENV FOR TESTING
+
+GRAPHQL_ENDPOINT: https://graphql-prod.curly-giggle.com
+
+// TODO: Remove before committing
+PROD_USER: curly
+PROD_PASS: some_bad_password
+
+// Feature Flags
+CURLY_FEATURE: true
+GIGGLE_FEATURE: false
+
+MAX_USERS: 2880 // test
+PORT: 443 // Set to a port not in use ya dummy

--- a/.env-tc-stage
+++ b/.env-tc-stage
@@ -1,0 +1,14 @@
+// EXAMPLE ENV FOR TESTING
+
+GRAPHQL_ENDPOINT: https://graphql-dev.curly-giggle.com
+
+// Feature Flags
+GIGGLE_FEATURE: false
+CURLY_FEATURE: true
+
+MAX_USERS: 1660 // Dont Increase!1!!1
+PORT: 443
+
+// TODO: Remove before committing
+DEV_USER: curly
+DEV_PASS: giggle

--- a/envdiff/diff.py
+++ b/envdiff/diff.py
@@ -1,20 +1,43 @@
 from envdiff.loader import Loader
 
 class Diff():
-    def __init__(self, left_file, right_file):
-        file_loader = Loader()
+    def __init__(self, left_file, right_file, comment='#', separator='='):
+        """
+        Initialise this class object
+        :left_file, The name of the first file
+        :right_file, The name of the second file
+        :comment, The characters used to indicate a comment
+        :separator, The characters used to indicate the key-value pair
+        """
+        self.separator_char = separator
 
         # Read lines from files into object properties
-        self.left = file_loader.read_file_contents(left_file)
-        self.right = file_loader.read_file_contents(right_file)
+        file_loader = Loader(comment)
+        self.left = file_loader.get_lines_of_interest(left_file)
+        self.right = file_loader.get_lines_of_interest(right_file)
 
-    def convert_to_dict(self, contents, delimiter):
-        return dict(line.split(delimiter) for line in contents)
+    def convert_to_dict(self, lines, delimiter):
+        """
+        Converts a list of strings and separates them into
+        key-value pairs (in a dictionary)
+        :lines, The list of strings to convert
+        :delimiter, The character(s) to separate the key-value pairs by
+        :return, A dictionary of the key-value pairs
+        """
+        return dict(line.split(delimiter) for line in lines)
 
     def diff(self):
+        """
+        Using the files previous loaded in the constructor, will return two
+        dicts: one detailing any unique keys found only in one of the files,
+        and another detailing any shared keys between the two files, and the
+        corresponding values of each.
+        :return, (shared_keys) The dictionary of shared keys;
+                 (unique_keys) The dictionary of unique keys;
+        """
         # Convert file contents to Dictionaries
-        left_dict = self.convert_to_dict(self.left, '=')
-        right_dict = self.convert_to_dict(self.right, '=')
+        left_dict = self.convert_to_dict(self.left, self.separator_char)
+        right_dict = self.convert_to_dict(self.right, self.separator_char)
 
         # Find shared & unique keys in each Dictionary
         shared_keys = self.find_distinct_shared_keys(left_dict, right_dict)
@@ -29,6 +52,13 @@ class Diff():
         return shared_list, unique_list
 
     def find_unique_keys(self, left_dict, right_dict):
+        """
+        Find the unique keys between two dictionaries
+        :left_dict, The first dictionary to compare
+        :right_dict, The second dictionary to compare
+        :return, A dictionary containing the unique keys in each file, in the format:
+                 { 'left': [ ...keys ], 'right': [ ...keys ] }
+        """
         # Convert list of keys to Sets
         left_keys = set(left_dict.keys())
         right_keys = set(right_dict.keys())
@@ -40,6 +70,13 @@ class Diff():
         return { 'left': list(left_unique), 'right': list(right_unique) }
 
     def find_distinct_shared_keys(self, left_dict, right_dict):
+        """
+        Find the shared keys between two dictionaries that have different values
+        :left_dict, The first dictionary to compare
+        :right_dict, The second dictionary to compare
+        :return, A dictionary containing the different shared keys in each file, in the format:
+                 { key: { left: 'value-1', right: 'value-2' }, ... }
+        """
         # Convert list of keys to Sets
         left_keys = set(left_dict.keys())
         right_keys = set(right_dict.keys())

--- a/envdiff/loader.py
+++ b/envdiff/loader.py
@@ -1,4 +1,7 @@
 class Loader():
+    def __init__(self, comment='#'):
+        self.comment_char = comment
+
     def read_file_contents(self, filename):
         """
         Reads and Returns the contents of a file
@@ -9,15 +12,6 @@ class Loader():
         with open(filename, mode='r', encoding='utf-8') as file:
             contents = file.read().splitlines()
 
-        # Removes empty lines
-        contents = list(filter(lambda item: item, contents))
-
-        # Remove commented out lines
-        contents = list(filter(self.comment_filter, contents))
-
-        # Trim lines with comments at the end
-        contents = [ line.split(' #')[0] for line in contents ]
-
         return contents
 
     def comment_filter(self, line):
@@ -26,4 +20,25 @@ class Loader():
         :line, The line to be filtered
         :return, True or False if the line should be kept in the result
         """
-        return line[0] != '#'
+        comment_char_len = len(self.comment_char)
+
+        return line[:comment_char_len] != self.comment_char
+
+    def get_lines_of_interest(self, filename):
+        """
+        Reads the given filename and returns only the lines
+        of interest - I.E. the ones with key-value pairs in them
+        :filename, The name of the file to be opened
+        """
+        file_contents = self.read_file_contents(filename)
+
+         # Removes empty lines
+        contents = list(filter(lambda item: item, file_contents))
+
+        # Remove commented out lines
+        contents = list(filter(self.comment_filter, contents))
+
+        # Trim lines with comments at the end
+        contents = [ line.split(f' {self.comment_char}')[0] for line in contents ]
+
+        return contents

--- a/main.py
+++ b/main.py
@@ -3,23 +3,24 @@ from sys import argv
 from envdiff.diff import Diff
 from envdiff.logger import Logger
 
-description = """
-Processes two environment files to determine
-differences between the same keys
-"""
-
 def main():
-    parser = argparse.ArgumentParser(description=description)
+    parser = argparse.ArgumentParser(description="""
+        Processes two environment files to determine
+        differences between the same keys
+        """
+    )
     parser.add_argument(
         '-c',
         '--comment',
-        help='Define the characters used to begin a comment'
-        )
+        help='Define the characters used to begin a comment',
+        default='#'
+    )
     parser.add_argument(
         '-s',
         '--separator',
-        help='Define the characters used to separate the key-value pairs'
-        )
+        help='Define the characters used to separate the key-value pairs',
+        default='='
+    )
     parser.add_argument('left', help='The filename of the first file')
     parser.add_argument('right', help='The filename of the second file')
 
@@ -28,13 +29,21 @@ def main():
         args = vars(parser.parse_args())
         left_file = args['left'];
         right_file = args['right'];
+        comment = args['comment']
+        separator = args['separator']
 
         # Initialise results logger
         logger = Logger()
         logger.print_title()
 
         # Do the diffing
-        differ = Diff(left_file=left_file, right_file=right_file)
+        differ = Diff(
+            left_file=left_file,
+            right_file=right_file,
+            comment=comment,
+            separator=separator
+        )
+
         shared, unique = differ.diff()
 
         # Print results

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -19,6 +19,14 @@ class TestDiff(unittest.TestCase):
 
         self.assertEqual(result, { 'FOO': 'BAR' })
 
+    def test_convert_to_dict_with_alternate_separator(self):
+        contents = ['FOO: BAR']
+
+        self.differ = Diff('test/fixtures/.env-simple', 'test/fixtures/.env-simple')
+        result = self.differ.convert_to_dict(contents, ': ')
+
+        self.assertEqual(result, { 'FOO': 'BAR' })
+
     def test_find_unique_keys(self):
         left = { 'FOO': 'BAR', 'LEFT': 'parsnip' }
         right = { 'FOO': 'BAR', 'RIGHT': 'persimmon' }

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -17,7 +17,7 @@ class TestLoader(unittest.TestCase):
     def test_does_not_include_commented_lines_or_new_lines(self):
         expected = ['KEY=VALUE']
 
-        result = self.loader.read_file_contents('test/fixtures/.env-with-comments')
+        result = self.loader.get_lines_of_interest('test/fixtures/.env-with-comments')
 
         self.assertEqual(result, expected)
         self.assertFalse(result.count(''))
@@ -25,7 +25,7 @@ class TestLoader(unittest.TestCase):
     def test_does_not_include_comments_that_follow_values(self):
         expected = ['FOO=BAR']
 
-        result = self.loader.read_file_contents('test/fixtures/.env-with-inline-comment')
+        result = self.loader.get_lines_of_interest('test/fixtures/.env-with-inline-comment')
 
         self.assertEqual(result, expected)
 
@@ -35,6 +35,15 @@ class TestLoader(unittest.TestCase):
 
         self.assertEqual(self.loader.comment_filter(test_line), True)
         self.assertEqual(self.loader.comment_filter(test_comment), False)
+
+    def test_comment_filter_with_custom_comment_character(self):
+        test_line = 'ENDPOINT=https://www.google.com/'
+        test_comment = '// This is a comment'
+
+        test_loader = Loader(comment='//')
+
+        self.assertEqual(test_loader.comment_filter(test_line), True)
+        self.assertEqual(test_loader.comment_filter(test_comment), False)
 
     def tearDown(self):
         self.loader = None


### PR DESCRIPTION
Not all environment variable files are the same. Some of them might separate key-value pairs using characters other than `=`, or might have a different set of characters, other than `#`, to indicate a comment.

This PR allows the user to pass custom comment & separator characters from the command line:
 - `-c "//"` - Use `//` as the comment indicator (defaults to `#`)
 - `-s ": "` - use `: ` as the key-value pair separator (defaults to `=`)